### PR TITLE
Update LTI for Canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ httpd2.pid
 httpd.pid
 lib/WebworkBridge/classlists/
 .dump_past_answers_salt
+.data

--- a/conf/localOverrides.conf.ubc.dist
+++ b/conf/localOverrides.conf.ubc.dist
@@ -465,22 +465,18 @@ $bridge{vista_login_options} = {
 };
 $bridge{vista_importer} = $webworkDirs{root} . "/lib/WebworkBridge/Bridges/vistawebworksimporter.jar";
 $bridge{vista_loginlist} = $webworkDirs{root} . "/lib/WebworkBridge/classlists/loginlist";
-$bridge{lti_loginlist} = $webworkDirs{root} . "/lib/WebworkBridge/classlists/loginlist_lti";
 
 # If a student does not have an email address, we check this file to see if
 # we can manually enter a student id for them. Note that if the LMS provides
 # an email address, we ignore this file and uses the LMS provided one.
 $bridge{emaillist} = $webworkDirs{root} . "/lib/WebworkBridge/classlists/emaillist";
 
-# the switch for launching LTI membership request on login
-# if the switch is off, the LTI requset has to have ubc_auto_update parameter to launch
-# membership the request
-$bridge{update_class_on_login} = 1;
-
 # define which LTI roles can launch the membership request.
 # AutoUpdater role is used by auto update script
 $bridge{roles_can_update} = 'Instructor ContentDeveloper AutoUpdater';
-$bridge{update_class_on_login} = 1;
+$bridge{launch_auto_manage_user_roles} = 'Instructor ContentDeveloper TeachingAssistant Learner';
+$bridge{hide_new_courses} = 1;
+$bridge{user_identifier_field} = 'custom_ubc_puid';
 
 # If a student does not have an email address, we check this file to see if
 # we can manually enter a student id for them. Note that if the LMS provides

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -312,6 +312,9 @@ sub dispatch($) {
 		{
 			MP2 ? $r->notes->set(import_error => $retstatus) : $r->notes('import_error' => $retstatus);
 		}
+		elsif (!$r->param('ext_ims_lis_memberships_url')) {
+			MP2 ? $r->notes->set(no_memebership => 1) : $r->notes('no_memebership' => 1);
+		}
 		$displayModule = $bridge->getDisplayModule();
 	}
 

--- a/lib/WeBWorK/Authen/LTI.pm
+++ b/lib/WeBWorK/Authen/LTI.pm
@@ -58,10 +58,10 @@ sub get_credentials {
 		$self->{error} = "$msgheader Undefined resource_link_id";
 		return 0;
 	}
-	if (!defined $r->param("lis_person_sourcedid")) 
-	{ # required
-		$self->{log_error} = "$msgheader Undefined lis_person_sourcedid";
-		$self->{error} = "$msgheader Undefined lis_person_sourcedid";
+	if (!defined $r->param($r->ce->{bridge}{user_identifier_field}))
+	{
+		$self->{log_error} = "$msgheader Undefined user identifier ".$r->ce->{bridge}{user_identifier_field};
+		$self->{error} = "$msgheader Undefined user identifier ".$r->ce->{bridge}{user_identifier_field};
 		return 0;
 	}
 	# set user id for the Authen module (inherited methods in particular)
@@ -71,7 +71,7 @@ sub get_credentials {
 	}
 	else 
 	{
-		$self->{user_id} = $r->param("lis_person_sourcedid");
+		$self->{user_id} = $r->param($r->ce->{bridge}{user_identifier_field});
 	}
 
 	debug("Checking for required OAuth parameters\n");

--- a/lib/WeBWorK/ContentGenerator/WebworkBridgeStatus.pm
+++ b/lib/WeBWorK/ContentGenerator/WebworkBridgeStatus.pm
@@ -41,12 +41,18 @@ sub body {
 
 	# check for error messages to display
 	my $import_error = MP2 ? $r->notes->get("import_error") : $r->notes("import_error");
+	my $no_memebership = MP2 ? $r->notes->get("no_memebership") : $r->notes("no_memebership");
 
 	if ($import_error)
 	{
 		print CGI::h2("Course Import Failed");
 		print CGI::p("Unfortunately, import failed. This might be a temporary condition. If it persists, please mail an error report with the time that the error occured and the exact error message below:");
 		print CGI::div({class=>"ResultsWithError"}, CGI::pre("$import_error") );
+	}
+	elsif ($no_memebership)
+	{
+		print CGI::h2("Course Import Successful");
+		print CGI::p("The course was successfully imported into Webwork.");
 	}
 	else
 	{

--- a/lib/WebworkBridge/Importer/CourseCreator.pm
+++ b/lib/WebworkBridge/Importer/CourseCreator.pm
@@ -74,6 +74,20 @@ sub runAddCourse
 	{ # script failed for some reason
 		return error("Add course failed, script failure: $msg", "e018");
 	}
+
+	if ($ce->{bridge}{hide_new_courses}) {
+		my $message = 'Place a file named "hide_directory" in a course or other directory '.
+			'and it will not show up in the courses list on the WeBWorK home page. '.
+			'It will still appear in the Course Administration listing.';
+		my $coursesDir = $ce->{webworkDirs}->{courses};
+		local *HIDEFILE;
+		if (open (HIDEFILE, ">","$coursesDir/$course/hide_directory")) {
+			print HIDEFILE "$message";
+			close HIDEFILE;
+		} else {
+			return error("Add course failed, hide directory failure", "e022");
+		}
+	}
 	return 0;
 }
 

--- a/lib/WebworkBridge/Importer/CourseUpdater.pm
+++ b/lib/WebworkBridge/Importer/CourseUpdater.pm
@@ -189,6 +189,13 @@ sub updateUser
 		$oldInfo->last_name($newInfo->{'lastname'});
 		$update = 1;
 	}
+	# lis_source_did (only if $newInfo set it)
+	if (defined($newInfo->{'lis_source_did'}) &&
+		$newInfo->{'lis_source_did'} ne $oldInfo->lis_source_did())
+	{
+		$oldInfo->lis_source_did($newInfo->{'lis_source_did'});
+		$update = 1;
+	}
 	# Batch update info
 	if ($update)
 	{
@@ -217,6 +224,12 @@ sub updateUser
 			$db->putUser($oldInfo);
 			$self->addlog("Teaching staff $id rejoined $courseid");
 		}
+	}
+
+	# assign all visible homeworks to students
+	if ($permission->permission() <= $ce->{userRoles}{student})
+	{
+		$self->assignAllVisibleSetsToUser($id, $db);
 	}
 }
 
@@ -248,7 +261,8 @@ sub addUser
 	$new_user->email_address($new_user_info->{'email'});
 	$new_user->status($status);
 	$new_user->student_id($new_user_info->{'studentid'});
-	
+	$new_user->lis_source_did($new_user_info->{'lis_source_did'});
+
 	# password record
 	my $cryptedpassword;
 	if ($new_user_info->{'password'})


### PR DESCRIPTION
- Existing LTI courses will need to manually have their lti parameters migrated from loginlist_lti to the course's settings table to allow automatic updates
- Added $bridge{launch_auto_manage_user_roles} to control which user roles are allowed to launch into webwork (all accounts will be automatically created/updated when a user launches into webwork)
- Automatic updates will no longer fail if membership is not available
- Launch requests will now fill in user.lis_source_did for course contexts and set_user.lis_source_did when linking to a homework set though custom_homework_set or custom_quiz
- LTI grade passback will now use a decimal score (canvas doesn't seem to support ratio)
- LTI grade passback for gateway assignments will now passback the best score (since passing back the grades for each version won't work with opaque lis_source_did
- updated the automatic update scripts to check each course for the lti_automatic_updates flag in the course settings table instead of checking listing in loginlist_lti. This also allowed to simplify the scripts in many ways.