### PR TITLE
Improve LTI automatic syncing

### DIFF
--- a/lib/WebworkBridge/Importer/CourseUpdater.pm
+++ b/lib/WebworkBridge/Importer/CourseUpdater.pm
@@ -215,12 +215,6 @@ sub updateUser
 			$self->addlog("Teaching staff $id rejoined $courseid");
 		}
 	}
-
-	# assign all visible homeworks to students
-	if ($permission->permission() <= $ce->{userRoles}{student})
-	{
-		$self->assignAllVisibleSetsToUser($id, $db);
-	}
 }
 
 sub addUser

--- a/lib/WebworkBridge/autoupdate.pl
+++ b/lib/WebworkBridge/autoupdate.pl
@@ -89,11 +89,11 @@ foreach my $ltiContext (@ltiContexts) {
 
 	if ($check)
 	{
-		$cmd = $ENV{WEBWORK_ROOT} . "/lib/WebworkBridge/checkclass_lti.pl $courseName $oauth_consumer_key $context_id";
+		$cmd = $ENV{WEBWORK_ROOT} . "/lib/WebworkBridge/checkclass_lti.pl '$courseName' '$oauth_consumer_key' '$context_id'";
 	}
 	else
 	{
-		$cmd = $ENV{WEBWORK_ROOT} . "/lib/WebworkBridge/updateclass_lti.pl $courseName $oauth_consumer_key $context_id $grade";
+		$cmd = $ENV{WEBWORK_ROOT} . "/lib/WebworkBridge/updateclass_lti.pl '$courseName' '$oauth_consumer_key' '$context_id' $grade";
 	}
 
 	my $ret = `$cmd\n`;

--- a/lib/WebworkBridge/updateclass_lti.pl
+++ b/lib/WebworkBridge/updateclass_lti.pl
@@ -60,10 +60,10 @@ if (substr($request_url, -1, 1) ne "/")
 
 my $ltiContext = $db->getLTIContext($oauth_consumer_key, $context_id);
 
-my $ext_ims_lis_memberships_id = $ltiContext->ext_ims_lis_memberships_id();
-my $ext_ims_lis_memberships_url = $ltiContext->ext_ims_lis_memberships_url();
-my $ext_ims_lis_basic_outcome_url = $ltiContext->ext_ims_lis_basic_outcome_url();
-my $custom_context_memberships_url = $ltiContext->custom_context_memberships_url();
+my $ext_ims_lis_memberships_id = $ltiContext->ext_ims_lis_memberships_id;
+my $ext_ims_lis_memberships_url = $ltiContext->ext_ims_lis_memberships_url;
+my $ext_ims_lis_basic_outcome_url = $ltiContext->ext_ims_lis_basic_outcome_url;
+my $custom_context_memberships_url = $ltiContext->custom_context_memberships_url;
 
 my %gradeParams;
 if (defined($grade))
@@ -108,7 +108,7 @@ $request->sign;
 my $ua = LWP::UserAgent->new;
 push @{ $ua->requests_redirectable }, 'POST';
 
-my $res = $ua->post($request_url, $request->to_hash);
+my $res = $ua->post($request_url . $courseName . "/", $request->to_hash);
 if ($res->is_success)
 {
 	if ($res->content =~ /Invalid user ID or password/)


### PR DESCRIPTION
- added logging to lti grade pushback (to help debug potential grade issues)
- moved `assignAllVisibleSetsToUser` that I added to `CourseUpdater.updateUser` to `LTIBridge._updateLaunchUser`. This might have been further slowing down lti membership ext syncs (though from my testing on staging it wasn't having any affect). by moving it into _updateLaunchUser we can still ensure that a user will be assigned all active assignments when they enter webwork via lti launch without performing this action for every user on membership update.
- removed `()` from lti context variable fetching in updateclass_lti.pl (might cause errors when a variable is empty)
- added single quotes around varables in `autoupdate.pl` (in case course name, consumer key, or context id ever contain anything that might be problematic for the command line)