### PR TITLE
Add lti option to skip auto assign homework

### DIFF
--- a/lib/WebworkBridge/Importer/CourseUpdater.pm
+++ b/lib/WebworkBridge/Importer/CourseUpdater.pm
@@ -319,6 +319,12 @@ sub addlog
 sub assignAllVisibleSetsToUser {
 	my ($self, $userID, $db) = @_;
 
+	# skip automatically assigning homeworksets if disabled for course
+	my $ltiAutoAssignHomeworksets = $db->getSettingValue('skipLTIAutomaticAssignHomeworksets');
+	if (defined($ltiAutoAssignHomeworksets) && $ltiAutoAssignHomeworksets eq "1") {
+		return;
+	}
+
 	my @globalSetIDs = $db->listGlobalSets;
 	my @GlobalSets = $db->getGlobalSets(@globalSetIDs);
 


### PR DESCRIPTION
Adding `skipLTIAutomaticAssignHomeworksets` with value `1` to course setting table will skip automatic homework set assignment (occurs on lti launch and sometimes when performing memberships extension)

Closes #14