### PR TITLE
Fix session key reset on problem set edit screen

### DIFF
--- a/htdocs/js/apps/ProblemSetDetail2/problemsetdetail2.js
+++ b/htdocs/js/apps/ProblemSetDetail2/problemsetdetail2.js
@@ -5,7 +5,7 @@ $(function() {
     $('#problemset_detail_list').addClass('container-fluid');
 
     //This sets ajax coos to be synchronous so as to not overwhelm the server
-    $.ajax({async : false});
+    //$.ajax({async : false});
 
     
     //This uses the nextedSortable jquery-ui module to drive the 


### PR DESCRIPTION
Introduced in 8ced0c78d the frontend would send a ajax request on screen load (no url provided so would use current url).
- On first page load there wouldn't be a problem since the user and session key are in the query string
- saving the form causes a post so user and session key are no longer in the query string when page reloads
- ajax request causes the authentication to fire again generating a new session key that the current browser window is not aware of (hence the next action is invalid)

Fixed by commenting out the ajax request since I don't think it does anything.
I believe the original intention was to make ajax requests on the page synchronous so not to overload the server but this doesn't actually do that (they might have meant to use `ajaxSetup()` which would effect future requests).