### PR TITLE
Fix LTI grade sync issue

### DIFF
--- a/lib/WebworkBridge/Bridges/LTIBridge.pm
+++ b/lib/WebworkBridge/Bridges/LTIBridge.pm
@@ -429,7 +429,7 @@ sub _ltiUpdateGrade()
 			return "Grade read failed for $lis_source_did, can't find user.";
 		}
 		elsif ($read_res->content =~ /textString>(.*)<\/textString/i) {
-			my $existing_score = sprintf("%.5f", $1);
+			my $existing_score = sprintf("%.4f", $1);
 			if ("$score" eq $existing_score) {
 				$extralog->logXML("Current Grade ($score) matches Tool Consumer ($existing_score). Update not neccissary.");
 				debug("Grade read successful for $lis_source_did. Update not neccissary.");

--- a/lib/WebworkBridge/Exporter/GradesExport.pm
+++ b/lib/WebworkBridge/Exporter/GradesExport.pm
@@ -156,11 +156,11 @@ sub getScore
 {
 	my ($self, $totalRight, $total) = @_;
 	if ($total <= 0 || $totalRight < 0) {
-		return 0;
+		return sprintf("%.4f", 0);
 	} elsif ($totalRight > $total) {
-		return 1;
+		return sprintf("%.4f", 1);
 	}
-	return sprintf("%.5f", $totalRight/$total);
+	return sprintf("%.4f", $totalRight/$total);
 }
 
 # Get the grades for a set.


### PR DESCRIPTION
- Will return float point formatted string for 0 and 1 edge cases
- Will send score for 4 digits (Canvas only operates on 4 digits so using 5 can cause rounding errors when comparing causing unnecessary updates)

See PRB0044038