### PR TITLE
Add Caliper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ RUN apt-get update \
        libxml-parser-perl \
        libxml-writer-perl \
        libapache2-reload-perl \
+       libnet-https-nb-perl \
+       libhttp-async-perl \
        make \
        netpbm \
        preview-latex-style \

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -119,6 +119,7 @@ my @modulesList = qw(
 	YAML
     XML::Simple
     App::Genpass
+	HTTP::Async
 );
 
 my %moduleVersion = (

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -437,5 +437,33 @@ $options{useOPLdefFiles}=1;
 # $permissionLevels{show_answer_hash_info_checkbox}	= "admin";
 # $permissionLevels{show_answer_group_info_checkbox}	= "admin";
 
+
+################################################################################
+# Webwork Caliper
+################################################################################
+
+# enable/disable Caliper for install
+$caliper{enabled} = 0;
+# base_url should ideally be hard coded to a persistent url pointing to the webwork root
+# (important to keep it consistent over time)
+$caliper{base_url} = 'https://webwork.elearning.ubc.ca/webwork2/';
+# LRS endpoint
+$caliper{host} = 'http://caliper.example.host.org/api/endpoint';
+# LRS endpoint Bearer API key
+$caliper{api_key} = '1234567890abcdefg';
+# log file for caliper errors
+$caliper{errorlog} = $webworkDirs{logs} . "/caliper_errors.log";
+# customized Caliper actor. Useful if persistent identifiers for students are available in WebWork
+# $caliper{custom_actor_generator} = sub {
+# 	my ($ce, $db, $user) = @_;
+# 	# set caliper id as needed
+# 	my $caliper_id = 'http://www.ubc.ca/' . $user->user_id();
+# 	return {
+# 		'id' => $caliper_id,
+# 		'type' => 'Person',
+# 		'name' => $user->first_name() . " " . $user->last_name(),
+# 	};
+# };
+
 # $permissionLevels{modify_tags} = "undef";
 1; #final line of the file to reassure perl that it was read properly.

--- a/conf/localOverrides.conf.ubc.dist
+++ b/conf/localOverrides.conf.ubc.dist
@@ -462,10 +462,20 @@ $caliper{custom_actor_generator} = sub {
 	my ($ce, $db, $user) = @_;
 	# set caliper id as needed
 	my $caliper_id = 'http://www.ubc.ca/' . $user->user_id();
+	my $otherIdentifiers = [];
+
+	# add lti user ids when available
+	# push @$otherIdentifiers, {
+	# 	'identifier' => ,
+	# 	'type' => 'SystemIdentifier',
+	# 	'identifierType' => 'LtiUserId',
+	# };
+
 	return {
 		'id' => $caliper_id,
 		'type' => 'Person',
 		'name' => $user->first_name() . " " . $user->last_name(),
+		'otherIdentifiers' => $otherIdentifiers,
 	};
 };
 

--- a/conf/localOverrides.conf.ubc.dist
+++ b/conf/localOverrides.conf.ubc.dist
@@ -442,6 +442,33 @@ $authen{'xmlrpc'} = "WeBWorK::Authen";
 
 
 
+################################################################################
+# Webwork Caliper
+################################################################################
+
+# enable/disable Caliper for install
+$caliper{enabled} = 1;
+# base_url should ideally be hard coded to a persistent url pointing to the webwork root
+# (important to keep it consistent over time)
+$caliper{base_url} = 'https://webwork.elearning.ubc.ca/webwork2/';
+# LRS endpoint
+$caliper{host} = 'http://caliper.example.host.org/api/endpoint';
+# LRS endpoint Bearer API key
+$caliper{api_key} = '1234567890abcdefg';
+# log file for caliper errors
+$caliper{errorlog} = $webworkDirs{logs} . "/caliper_errors.log";
+# customized Caliper actor. Useful if persistent identifiers for students are available in WebWork
+$caliper{custom_actor_generator} = sub {
+	my ($ce, $db, $user) = @_;
+	# set caliper id as needed
+	my $caliper_id = 'http://www.ubc.ca/' . $user->user_id();
+	return {
+		'id' => $caliper_id,
+		'type' => 'Person',
+		'name' => $user->first_name() . " " . $user->last_name(),
+	};
+};
+
 
 ################################################################################
 # Webwork Bridge

--- a/lib/Caliper/Actor.pm
+++ b/lib/Caliper/Actor.pm
@@ -13,7 +13,7 @@ use Caliper::ResourceIri;
 sub generate_anonymous_actor
 {
 	return {
-		'id' => 'http://purl.imsglobal.org/ctx/caliper/v1p1/Person',
+		'id' => 'http://purl.imsglobal.org/caliper/Person',
 		'type' => 'Person',
 	};
 }

--- a/lib/Caliper/Actor.pm
+++ b/lib/Caliper/Actor.pm
@@ -1,0 +1,50 @@
+package Caliper::Actor;
+
+##### Library Imports #####
+use strict;
+use warnings;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Debug;
+use Data::Dumper;
+
+use Caliper::ResourceIri;
+
+sub generate_anonymous_actor
+{
+	return {
+		'id' => 'http://purl.imsglobal.org/ctx/caliper/v1p1/Person',
+		'type' => 'Person',
+	};
+}
+
+sub generate_default_actor
+{
+	my ($ce, $db, $user) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	return {
+		'id' => $resource_iri->actor_homepage($user->user_id()),
+		'type' => 'Person',
+		'name' => $user->first_name() . " " . $user->last_name(),
+	};
+}
+
+sub generate_actor
+{
+	my ($ce, $db, $user_id) = @_;
+
+	if (!defined($user_id)) {
+		return Caliper::Entity::generate_anonymous_actor();
+	} else {
+		my $user = $db->getUser($user_id);
+
+		if (defined($ce->{caliper}{custom_actor_generator})) {
+			return $ce->{caliper}{custom_actor_generator}($ce, $db, $user);
+		} else {
+			return Caliper::Entity::generate_default_actor($ce, $db, $user);
+		}
+	}
+}
+
+1;

--- a/lib/Caliper/Actor.pm
+++ b/lib/Caliper/Actor.pm
@@ -42,7 +42,7 @@ sub generate_actor
 		if (defined($ce->{caliper}{custom_actor_generator})) {
 			return $ce->{caliper}{custom_actor_generator}($ce, $db, $user);
 		} else {
-			return Caliper::Entity::generate_default_actor($ce, $db, $user);
+			return generate_default_actor($ce, $db, $user);
 		}
 	}
 }

--- a/lib/Caliper/Entity.pm
+++ b/lib/Caliper/Entity.pm
@@ -1,0 +1,378 @@
+package Caliper::Entity;
+
+##### Library Imports #####
+use strict;
+use warnings;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Debug;
+use Data::Dumper;
+use WeBWorK::Utils::Tags;
+
+use Caliper::ResourceIri;
+use Caliper::Sensor;
+use Caliper::Actor;
+use WeBWorK::Utils qw(grade_set grade_gateway);
+
+sub webwork_app
+{
+	my ($ce, $db) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	# $ce doesn't have WW_VERSION when doing login/logout for some reason
+	my $webwork_dir  = $WeBWorK::Constants::WEBWORK_DIRECTORY;
+	my $seed_ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_dir });
+	my $ww_version = $seed_ce->{WW_VERSION}||"unknown";
+
+	return {
+		'id' => $resource_iri->webwork(),
+		'type' => 'SoftwareApplication',
+		'name' => 'WeBWorK',
+		'version' => $ww_version,
+	};
+}
+
+sub session
+{
+	my ($ce, $db, $actor, $session_key) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	return {
+		'id' => $resource_iri->user_session($session_key),
+		'type' => 'Session',
+		'user' => $actor,
+	};
+}
+
+sub membership
+{
+	my ($ce, $db, $actor, $user_id) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $user = $db->getUser($user_id);
+	my $permission = $db->getPermissionLevel($user_id);
+
+	my $roles = [];
+	my $status = '';
+
+	if ($user->status() ne 'D') {
+		$status = 'Active';
+	} else {
+		$status = 'Inactive';
+	}
+
+	if ($permission->permission() == $ce->{userRoles}{admin}) {
+		push @$roles, 'Administrator';
+	} elsif ($permission->permission() == $ce->{userRoles}{professor}) {
+		push @$roles, 'Instructor';
+	} elsif ($permission->permission() == $ce->{userRoles}{ta}) {
+		push @$roles, 'Instructor';
+		push @$roles, 'Instructor#TeachingAssistant';
+	} elsif ($permission->permission() == $ce->{userRoles}{grade_proctor}) {
+		push @$roles, 'Instructor';
+		push @$roles, 'Instructor#Grader';
+	} elsif ($permission->permission() == $ce->{userRoles}{login_proctor}) {
+		push @$roles, 'Instructor';
+		push @$roles, 'Instructor#GuestInstructor';
+	} elsif ($permission->permission() == $ce->{userRoles}{student}) {
+		push @$roles, 'Learner';
+	}
+	# guest and nobody aren't tracked
+
+	return {
+		'id' => $resource_iri->user_membership($user_id),
+		'type' => 'Membership',
+		'member' => $actor,
+		'organization' => $resource_iri->course(),
+		'roles' => $roles,
+		'status' => $status,
+	};
+}
+
+sub course
+{
+	my ($ce, $db) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $course_entity = {
+		'id' => $resource_iri->course(),
+		'type' => 'CourseOffering',
+	};
+
+	if ($db->settingExists('courseTitle')) {
+		$course_entity->{'name'} = $db->getSettingValue('courseTitle');
+	}
+
+	return $course_entity;
+}
+
+sub problem_set
+{
+	my ($ce, $db, $set_id) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $problem_set = $db->getGlobalSet($set_id);
+
+	my $items = [];
+	my @problem_ids = $db->listGlobalProblems($set_id);
+	for my $problem_id (@problem_ids) {
+		push(@$items, {
+			'id' => $resource_iri->problem($set_id, $problem_id),
+			'type' => 'AssessmentItem',
+		});
+	}
+
+	my $problem_set_entity = {
+		'id' => $resource_iri->problem_set($set_id),
+		'type' => 'Assessment',
+		'isPartOf' => Caliper::Entity::course($ce, $db),
+		'name' => $set_id,
+		'items' => $items,
+		'dateToStartOn' => Caliper::Sensor::formatted_timestamp($problem_set->open_date()),
+		'dateToSubmit' => Caliper::Sensor::formatted_timestamp($problem_set->due_date()),
+		'extensions' => {
+			'answer_date' => $problem_set->answer_date(),
+			'reduced_scoring_date' => $problem_set->reduced_scoring_date(),
+			'visible' => $problem_set->visible(),
+			'enable_reduced_scoring' => $problem_set->enable_reduced_scoring(),
+			'description' => $problem_set->description(),
+			'restricted_release' => $problem_set->restricted_release(),
+			'restricted_status' => $problem_set->restricted_status(),
+			'attempts_per_version' => $problem_set->attempts_per_version(),
+			'time_interval' => $problem_set->time_interval(),
+			'versions_per_interval' => $problem_set->versions_per_interval(),
+			'version_time_limit' => $problem_set->version_time_limit(),
+			'version_creation_time' => $problem_set->version_creation_time(),
+			'problem_randorder' => $problem_set->problem_randorder(),
+			'version_last_attempt_time' => $problem_set->version_last_attempt_time(),
+			'problems_per_page' => $problem_set->problems_per_page(),
+			'hide_score' => $problem_set->hide_score(),
+			'hide_score_by_problem' => $problem_set->hide_score_by_problem(),
+			'hide_work' => $problem_set->hide_work(),
+			'time_limit_cap' => $problem_set->time_limit_cap(),
+			'restrict_ip' => $problem_set->restrict_ip(),
+			'relax_restrict_ip' => $problem_set->relax_restrict_ip(),
+			'restricted_login_proctor' => $problem_set->restricted_login_proctor(),
+			'hide_hint' => $problem_set->hide_hint(),
+			'restrict_prob_progression' => $problem_set->restrict_prob_progression(),
+		}
+	};
+
+	if (defined($problem_set->description()) && $problem_set->description() ne '') {
+		$problem_set_entity->{'description'} = $problem_set->description();
+	}
+
+	return $problem_set_entity;
+}
+
+sub problem
+{
+	my ($ce, $db, $set_id, $problem_id) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $problem = $db->getGlobalProblem($set_id, $problem_id);
+
+	my $templateDir = $ce->{courseDirs}->{templates};
+	my $tags = WeBWorK::Utils::Tags->new($templateDir.'/'.$problem->source_file());
+	my $keywords = $tags->{'keywords'};
+	$_ =~ s/(^[\s"']+)|([\s"']+$)//g for @$keywords;
+
+	my %tags_ref = %$tags;
+	my $unblessed_tags = \%tags_ref;
+
+	return {
+		'id' => $resource_iri->problem($set_id, $problem_id),
+		'type' => 'AssessmentItem',
+		'name' => 'Problem ' . $problem_id,
+		'isPartOf' => Caliper::Entity::problem_set($ce, $db, $set_id),
+		'keywords' => $keywords,
+		'extensions' => {
+			'source_file' => $problem->source_file(),
+			'value' => $problem->value(),
+			'max_attempts' => $problem->max_attempts(),
+			'att_to_open_children' => $problem->att_to_open_children(),
+			'counts_parent_grade' => $problem->counts_parent_grade(),
+			'showMeAnother' => $problem->showMeAnother(),
+			'showMeAnotherCount' => $problem->showMeAnotherCount(),
+			'prPeriod' => $problem->prPeriod(),
+			'prCount' => $problem->prCount(),
+			'flags' => $problem->flags(),
+			'tags' => $unblessed_tags,
+		},
+	};
+}
+
+sub problem_user
+{
+	my ($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $problem_user = $version_id ?
+		$db->getMergedProblemVersion($user_id, $set_id, $version_id, $problem_id) :
+		$db->getMergedProblem($user_id, $set_id, $problem_id);
+
+	my $templateDir = $ce->{courseDirs}->{templates};
+	my $tags = WeBWorK::Utils::Tags->new($templateDir.'/'.$problem_user->source_file());
+	my $keywords = $tags->{'keywords'};
+	$_ =~ s/(^[\s"']+)|([\s"']+$)//g for @$keywords;
+
+	my %tags_ref = %$tags;
+	my $unblessed_tags = \%tags_ref;
+
+	my $correct_answers = [];
+	foreach my $ans_id (@{$pg->{flags}->{ANSWER_ENTRY_ORDER}//[]} ) {
+		push @$correct_answers, $pg->{'answers'}->{$ans_id}->{'correct_value'};
+	}
+
+	return {
+		'id' => $resource_iri->problem_user($set_id, $problem_id, $user_id),
+		'type' => 'AssessmentItem',
+		'name' => 'Problem ' . $problem_id,
+		'isPartOf' => Caliper::Entity::problem($ce, $db, $set_id, $problem_id),
+		'keywords' => $keywords,
+		'extensions' => {
+			'correct_answers' => $correct_answers,
+			'source_file' => $problem_user->source_file(),
+			'value' => $problem_user->value(),
+			'max_attempts' => $problem_user->max_attempts(),
+			'att_to_open_children' => $problem_user->att_to_open_children(),
+			'counts_parent_grade' => $problem_user->counts_parent_grade(),
+			'showMeAnother' => $problem_user->showMeAnother(),
+			'showMeAnotherCount' => $problem_user->showMeAnotherCount(),
+			'prPeriod' => $problem_user->prPeriod(),
+			'prCount' => $problem_user->prCount(),
+			'flags' => $problem_user->flags(),
+			'tags' => $unblessed_tags,
+			'problem_seed' => $problem_user->problem_seed(),
+			'source_text' => $problem_user->status(),
+			'problem_source_code' => $pg->{'translator'}->{'source'},
+			'problem_html_text' => $pg->{'body_text'},
+			'status' => $problem_user->status(),
+			'attempted' => $problem_user->attempted(),
+			'last_answer' => $problem_user->last_answer(),
+			'num_correct' => $problem_user->num_correct(),
+			'num_incorrect' => $problem_user->num_incorrect(),
+			'sub_status' => $problem_user->sub_status(),
+		}
+	};
+}
+
+sub answer
+{
+	my ($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg, $start_time, $end_time) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $last_answer_id = $db->latestProblemPastAnswer($ce->{"courseName"}, $user_id, ($version_id ? "$set_id,v$version_id" : $set_id), $problem_id);
+	my $last_answer = $db->getPastAnswer($last_answer_id);
+	my @answers = split(/\t/, $last_answer->answer_string());
+
+	my $pg_answers_hash = {};
+	foreach my $key (keys %{$pg->{'answers'}})
+	{
+		my %answer_ref = %{$pg->{'answers'}->{$key}};
+		my $unblessed_answer = \%answer_ref;
+		$pg_answers_hash->{$key} = $unblessed_answer;
+	}
+
+	return {
+		'id' => $resource_iri->answer($set_id, $problem_id, $user_id),
+		'type' => 'FillinBlankResponse',
+		'attempt' => Caliper::Entity::answer_attempt($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg, $start_time, $end_time),
+		'values' => \@answers,
+		'extensions' => {
+			'source_file' => $last_answer->source_file(),
+			'scores' => $last_answer->scores(),
+			'comment' => $last_answer->comment_string(),
+			'pg_answers_hash' => $pg_answers_hash,
+		}
+	};
+}
+
+sub answer_attempt
+{
+	my ($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg, $start_time, $end_time) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $problem_user = $version_id ?
+		$db->getMergedProblemVersion($user_id, $set_id, $version_id, $problem_id) :
+		$db->getMergedProblem($user_id, $set_id, $problem_id);
+	my $last_answer_id = $db->latestProblemPastAnswer($ce->{"courseName"}, $user_id, ($version_id ? "$set_id,v$version_id" : $set_id), $problem_id);
+	my $last_answer = $db->getPastAnswer($last_answer_id);
+	my $attempt = $version_id ? $version_id : scalar $db->listProblemPastAnswers($ce->{"courseName"}, $user_id, $set_id, $problem_id);
+    my $score = $problem_user->status || 0;
+	$score = 0 if ($score > 1 || $score < 0 );
+
+	my $answer_attempt = {
+		'id' => $resource_iri->answer_attempt($set_id, $problem_id, $user_id, $last_answer->answer_id()),
+		'type' => 'Attempt',
+		'assignee' => Caliper::Actor::generate_actor($ce, $db, $user_id),
+		'assignable' => $resource_iri->problem_user($set_id, $problem_id, $user_id),
+		'count' => $attempt + 0, #ensure int
+		'dateCreated' => Caliper::Sensor::formatted_timestamp($last_answer->timestamp()),
+		'extensions' => {
+			'attempt_score' => $score,
+		}
+	};
+
+	if ($start_time) {
+		$answer_attempt->{'startedAtTime'} = Caliper::Sensor::formatted_timestamp($start_time);
+
+		if ($end_time) {
+			$answer_attempt->{'endedAtTime'} = Caliper::Sensor::formatted_timestamp($end_time);
+			$answer_attempt->{'duration'} = Caliper::Sensor::formatted_duration($end_time - $start_time);
+		}
+	}
+
+	return $answer_attempt;
+}
+
+sub problem_set_attempt
+{
+	my ($ce, $db, $set_id, $version_id, $user_id, $start_time, $end_time) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	my $problem_set_user = $version_id ?
+		$db->getMergedSetVersion($user_id, $set_id, $version_id) :
+		$db->getMergedSet($user_id, $set_id);
+
+	my $attempt = 0;
+	if ($version_id) {
+		$attempt = $version_id;
+	} else {
+		my @problem_ids = $db->listGlobalProblems($set_id);
+		for my $problem_id (@problem_ids) {
+			$attempt += scalar $db->listProblemPastAnswers($ce->{"courseName"}, $user_id, $set_id, $problem_id);
+		}
+	}
+
+	my $score = grade_set($db, $problem_set_user, $problem_set_user->set_id, $user_id, ($version_id ? 1 : 0));
+	my $extensions = {
+		'attempt_score' => $score,
+	};
+
+	if ($version_id) {
+		$extensions->{'gateway_score'} = grade_gateway($db, $problem_set_user, $problem_set_user->set_id, $user_id);
+	}
+
+	my $problem_set_attempt = {
+		'id' => $resource_iri->problem_set_attempt($set_id, $user_id, $attempt),
+		'type' => 'Attempt',
+		'assignee' => Caliper::Actor::generate_actor($ce, $db, $user_id),
+		'assignable' => $resource_iri->problem_set($set_id),
+		'count' => $attempt + 0, #ensure int
+		'extensions' => $extensions,
+	};
+
+	if ($start_time) {
+		$problem_set_attempt->{'startedAtTime'} = Caliper::Sensor::formatted_timestamp($start_time);
+
+		if ($end_time) {
+			$problem_set_attempt->{'endedAtTime'} = Caliper::Sensor::formatted_timestamp($end_time);
+			$problem_set_attempt->{'duration'} = Caliper::Sensor::formatted_duration($end_time - $start_time);
+		}
+	}
+
+	return $problem_set_attempt;
+}
+
+1;

--- a/lib/Caliper/Entity.pm
+++ b/lib/Caliper/Entity.pm
@@ -41,6 +41,21 @@ sub session
 		'id' => $resource_iri->user_session($session_key),
 		'type' => 'Session',
 		'user' => $actor,
+		'client' => Caliper::Entity::client($ce, $db, $session_key),
+	};
+}
+
+sub client
+{
+	my ($ce, $db, $session_key) = @_;
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+
+	return {
+		'id' => $resource_iri->user_client($session_key),
+		'type' => 'SoftwareApplication',
+		'userAgent' => $ENV{HTTP_USER_AGENT},
+		'ipAddress' => $ENV{REMOTE_ADDR},
+		'host' => $ENV{HTTP_HOST},
 	};
 }
 

--- a/lib/Caliper/Event.pm
+++ b/lib/Caliper/Event.pm
@@ -1,0 +1,56 @@
+package Caliper::Event;
+
+##### Library Imports #####
+use strict;
+use warnings;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Debug;
+use Data::Dumper;
+use Data::UUID;
+
+use Caliper::Actor;
+use Caliper::Sensor;
+
+# Constructor
+sub add_defaults
+{
+	my ($r, $event_hash) = @_;
+	my $ce = $r->{ce};
+	my $db = $r->{db};
+	my $ug = new Data::UUID;
+
+	my $user_id = $r->param('user');
+	my $session_key = $r->param('key');
+	my $uuid = $ug->create_str;
+	my $actor = Caliper::Actor::generate_actor($ce, $db, $user_id);
+
+	if (!exists($event_hash->{'@context'})) {
+		$event_hash->{'@context'} = 'http://purl.imsglobal.org/ctx/caliper/v1p1';
+	}
+	$event_hash->{'id'} = 'urn:uuid:' . $uuid;
+	$event_hash->{'actor'} = $actor;
+	$event_hash->{'session'} = Caliper::Entity::session($ce, $db, $actor, $session_key);
+	$event_hash->{'edApp'} = Caliper::Entity::webwork_app($ce, $db);
+	$event_hash->{'group'} = Caliper::Entity::course($ce, $db);
+	$event_hash->{'membership'} = Caliper::Entity::membership($ce, $db, $actor, $user_id);
+	if (!exists($event_hash->{'eventTime'})) {
+		$event_hash->{'eventTime'} = Caliper::Sensor::formatted_timestamp(time());
+	}
+
+	if (!exists($event_hash->{'extensions'})) {
+		$event_hash->{'extensions'} = ();
+	}
+	$event_hash->{'extensions'}{'browser-info'} = ();
+	if (defined($ENV{HTTP_USER_AGENT})) {
+		$event_hash->{'extensions'}{'browser-info'}{'userAgent'} = $ENV{HTTP_USER_AGENT};
+	}
+	if (defined($ENV{HTTP_REFERER})) {
+		$event_hash->{'extensions'}{'browser-info'}{'referer'} = $ENV{HTTP_REFERER};
+	}
+	if (defined($ENV{REMOTE_ADDR})) {
+		$event_hash->{'extensions'}{'browser-info'}{'ipAddress'} = $ENV{REMOTE_ADDR};
+	}
+}
+
+1;

--- a/lib/Caliper/Event.pm
+++ b/lib/Caliper/Event.pm
@@ -26,7 +26,7 @@ sub add_defaults
 	my $actor = Caliper::Actor::generate_actor($ce, $db, $user_id);
 
 	if (!exists($event_hash->{'@context'})) {
-		$event_hash->{'@context'} = 'http://purl.imsglobal.org/ctx/caliper/v1p1';
+		$event_hash->{'@context'} = 'http://purl.imsglobal.org/ctx/caliper/v1p2';
 	}
 	$event_hash->{'id'} = 'urn:uuid:' . $uuid;
 	$event_hash->{'actor'} = $actor;
@@ -41,15 +41,8 @@ sub add_defaults
 	if (!exists($event_hash->{'extensions'})) {
 		$event_hash->{'extensions'} = ();
 	}
-	$event_hash->{'extensions'}{'browser-info'} = ();
-	if (defined($ENV{HTTP_USER_AGENT})) {
-		$event_hash->{'extensions'}{'browser-info'}{'userAgent'} = $ENV{HTTP_USER_AGENT};
-	}
 	if (defined($ENV{HTTP_REFERER})) {
-		$event_hash->{'extensions'}{'browser-info'}{'referer'} = $ENV{HTTP_REFERER};
-	}
-	if (defined($ENV{REMOTE_ADDR})) {
-		$event_hash->{'extensions'}{'browser-info'}{'ipAddress'} = $ENV{REMOTE_ADDR};
+		$event_hash->{'extensions'}{'referer'} = $ENV{HTTP_REFERER};
 	}
 }
 

--- a/lib/Caliper/ResourceIri.pm
+++ b/lib/Caliper/ResourceIri.pm
@@ -63,6 +63,12 @@ sub user_session
 	return $self->getBaseUrl() . 'session/'. $session_key;
 }
 
+sub user_client
+{
+	my ($self, $session_key) = @_;
+	return $self->user_session($session_key) . '/client';
+}
+
 sub user_membership
 {
 	my ($self, $user_id) = @_;

--- a/lib/Caliper/ResourceIri.pm
+++ b/lib/Caliper/ResourceIri.pm
@@ -1,0 +1,114 @@
+package Caliper::ResourseIri;
+
+##### Library Imports #####
+use strict;
+use warnings;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Debug;
+use Data::Dumper;
+
+
+# Constructor
+sub new
+{
+	my ($class, $ce) = @_;
+
+	# need to use $seed_ce in case of logout
+	my $webwork_dir  = $WeBWorK::Constants::WEBWORK_DIRECTORY;
+	my $seed_ce = new WeBWorK::CourseEnvironment({ webwork_dir => $webwork_dir });
+	my $base_url = $seed_ce->{server_root_url} . $seed_ce->{webwork_url};
+	if (defined($seed_ce->{caliper}{base_url}) && $seed_ce->{caliper}{base_url} ne '') {
+		$base_url = $seed_ce->{caliper}{base_url};
+	}
+	if (substr($base_url, -1, 1) ne "/") {
+		$base_url .= "/";
+	}
+
+	my $self = {
+		ce => $ce,
+		base_url => $base_url,
+	};
+	bless $self, $class;
+	return $self;
+}
+
+sub getBaseUrl
+{
+	my $self = shift;
+	return $self->{base_url};
+}
+
+sub webwork
+{
+	my $self = shift;
+	return $self->getBaseUrl();
+}
+
+sub course
+{
+	my $self = shift;
+	return $self->getBaseUrl() . $self->{ce}->{"courseName"} . '/';
+}
+
+sub actor_homepage
+{
+	my ($self, $user_id) = @_;
+	return $self->course() . 'users/'.$user_id;
+}
+
+sub user_session
+{
+	my ($self, $session_key) = @_;
+	return $self->getBaseUrl() . 'session/'. $session_key;
+}
+
+sub user_membership
+{
+	my ($self, $user_id) = @_;
+	return $self->course() . 'instructor/users2/?visible_users='.$user_id;
+}
+
+sub problem_set
+{
+	my ($self, $set_id) = @_;
+	return $self->course() . $set_id . '/';
+}
+
+sub problem_set_user
+{
+	my ($self, $set_id, $user_id) = @_;
+	return $self->problem_set($set_id) . '?effectiveUser=' . $user_id;
+}
+
+sub problem
+{
+	my ($self, $set_id, $problem_id) = @_;
+	return $self->problem_set($set_id) . $problem_id . '/';
+}
+
+sub problem_user
+{
+	my ($self, $set_id, $problem_id, $user_id) = @_;
+	return $self->problem($set_id, $problem_id) . '?effectiveUser=' . $user_id;
+}
+
+sub answer
+{
+	my ($self, $set_id, $problem_id, $user_id) = @_;
+	return $self->problem($set_id, $problem_id) . 'answer/' . '?effectiveUser=' . $user_id;
+}
+
+sub answer_attempt
+{
+	my ($self, $set_id, $problem_id, $user_id, $answer_id) = @_;
+	return $self->answer($set_id, $problem_id, $user_id) . '&answer_id=' . $answer_id;
+}
+
+sub problem_set_attempt
+{
+	my ($self, $set_id, $user_id, $attempt) = @_;
+	return $self->problem_set_user($set_id, $user_id) . '&attempt=' . $attempt;
+}
+
+1;

--- a/lib/Caliper/Sensor.pm
+++ b/lib/Caliper/Sensor.pm
@@ -66,7 +66,7 @@ sub sendEvents
 		my $envelope = {
 			'sensor' => $resource_iri->webwork(),
 			'sendTime' => Caliper::Sensor::formatted_timestamp(time()),
-			'dataVersion' => 'http://purl.imsglobal.org/ctx/caliper/v1p1',
+			'dataVersion' => 'http://purl.imsglobal.org/ctx/caliper/v1p2',
 			'data' => $event_chunk,
 		};
 

--- a/lib/Caliper/Sensor.pm
+++ b/lib/Caliper/Sensor.pm
@@ -1,0 +1,149 @@
+package Caliper::Sensor;
+
+##### Library Imports #####
+use strict;
+use warnings;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Debug;
+use Data::Dumper;
+use JSON;
+use Time::HiRes qw/gettimeofday/;
+use Date::Format;
+
+use HTTP::Request::Common;
+use HTTP::Async;
+
+use Caliper::Event;
+use Caliper::ResourceIri;
+
+
+# Constructor
+sub new
+{
+	my ($class, $ce) = @_;
+	my $self = {
+		ce => $ce,
+		enabled => $ce->{caliper}{enabled},
+		host => $ce->{caliper}{host},
+		api_key => $ce->{caliper}{api_key}
+	};
+	bless $self, $class;
+	return $self;
+}
+
+sub caliperEnabled
+{
+	my $self = shift;
+	return $self->{enabled} && exists $self->{host} && exists $self->{api_key};
+}
+
+sub sendEvent
+{
+	my ($self, $r, $event_hash) = @_;
+
+	return $self->sendEvents($r, [ $event_hash ]);
+}
+
+sub sendEvents
+{
+	my ($self, $r, $array_of_events) = @_;
+	return 0 unless $self->caliperEnabled();
+
+	for my $event_hash (@$array_of_events) {
+		Caliper::Event::add_defaults($r, $event_hash);
+	}
+
+	my $ce = $r->{ce};
+	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $async = HTTP::Async->new;
+
+	# chunk events to prevent size issues (send a maximum of 3 events at a time)
+	my $event_chunks = [];
+	push(@$event_chunks, [ splice @$array_of_events, 0, 3 ]) while @$array_of_events;
+
+	for my $event_chunk (@$event_chunks) {
+		my $envelope = {
+			'sensor' => $resource_iri->webwork(),
+			'sendTime' => Caliper::Sensor::formatted_timestamp(time()),
+			'dataVersion' => 'http://purl.imsglobal.org/ctx/caliper/v1p1',
+			'data' => $event_chunk,
+		};
+
+		my $json_payload = JSON->new->canonical->encode($envelope);
+		# debug("Caliper event json_payload: " . $json_payload);
+
+		my $HTTPRequest = HTTP::Request->new('POST', $self->{host}, [
+			'Accept' => '*/*',
+			'Authorization' => 'Bearer ' . $self->{api_key},
+			'Content-Type' => 'application/json',
+		], $json_payload);
+		$async->add($HTTPRequest);
+	}
+
+	while ( my $response = $async->wait_for_next_response ) {
+		if (!$response->is_success) {
+			debug("Caliper event post failed. Error Message: " . $response->message);
+			debug($response->content);
+			$self->log_error("Caliper event post failed. Error Message: ". $response->message . "\nResponse Content: ". $response->content);
+		} else {
+			debug("Caliper event post success. Success Message: " . $response->message);
+			debug($response->content);
+		}
+	}
+}
+
+sub log_error
+{
+	my ($self, $error_message) = @_;
+	my $ce = $self->{ce};
+	my $logfile = $ce->{caliper}{errorlog};
+
+	my ($sec, $msec) = gettimeofday;
+	my $date = time2str("%a %b %d %H:%M:%S.$msec %Y", $sec);
+	my $msg = "[$date] $error_message\n";
+
+	# create if necessary
+	unless (-e $logfile) {
+		open my $fc, ">", $logfile;
+		close $fc;
+	}
+	# append message
+	if (open my $f, ">>", $logfile) {
+		print $f $msg;
+		close $f;
+	}
+	else {
+		debug("Error, unable to open caliper error log file '$logfile' in append mode: $!");
+	}
+}
+
+sub formatted_timestamp
+{
+	my ($time_value) = @_;
+	# Note: webwork epoch timestamps do not include milliseconds
+	return POSIX::strftime("%Y-%m-%dT%H:%M:%S.000Z", gmtime($time_value));
+}
+
+sub formatted_duration
+{
+	my ($duration) = @_;
+
+	# gererate the time portion of a ISO 8601 formatted duration
+	my $seconds = $duration % 60;
+	my $minutes = int($duration / 60) % 60;
+	my $hours = int($duration / 3600);
+
+	my $output = "PT";
+	if ($hours > 0) {
+		$output .= $hours ."H";
+	}
+	if ($hours > 0 || $minutes > 0) {
+		$output .= $minutes."M";
+	}
+	$output .= $seconds ."S";
+
+	return $output;
+}
+
+1;

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -64,6 +64,9 @@ use Scalar::Util qw(weaken);
 use mod_perl;
 use constant MP2 => ( exists $ENV{MOD_PERL_API_VERSION} and $ENV{MOD_PERL_API_VERSION} >= 2 );
 
+use Caliper::Sensor;
+use Caliper::Entity;
+
 #####################
 ## WeBWorK-tr modification
 ## If GENERIC_ERROR_MESSAGE is constant, we can't translate it
@@ -246,6 +249,16 @@ sub verify {
 		}
 	}
 	
+	my $caliper_sensor = Caliper::Sensor->new($self->{r}->ce);
+	if ($caliper_sensor->caliperEnabled() && $result && $self->{initial_login}) {
+		my $login_event = {
+			'type' => 'SessionEvent',
+			'action' => 'LoggedIn',
+			'object' => Caliper::Entity::webwork_app()
+		};
+		$caliper_sensor->sendEvents($self->{r}, [$login_event]);
+	}
+
 	debug("END VERIFY");
 	debug("result $result");
 	return $result;
@@ -783,6 +796,16 @@ sub killSession {
 	my $r = $self -> {r};
 	my $ce = $r -> {ce};
 	my $db = $r -> {db};
+
+	my $caliper_sensor = Caliper::Sensor->new($ce);
+	if ($caliper_sensor->caliperEnabled()) {
+		my $login_event = {
+			'type' => 'SessionEvent',
+			'action' => 'LoggedOut',
+			'object' => Caliper::Entity::webwork_app()
+		};
+		$caliper_sensor->sendEvents($self->{r}, [$login_event]);
+	}
 
 	$self -> forget_verification;
 	if ($ce -> {session_management_via} eq "session_cookie")  {

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -254,6 +254,7 @@ sub verify {
 		my $login_event = {
 			'type' => 'SessionEvent',
 			'action' => 'LoggedIn',
+			'profile' => 'SessionProfile',
 			'object' => Caliper::Entity::webwork_app()
 		};
 		$caliper_sensor->sendEvents($self->{r}, [$login_event]);
@@ -802,6 +803,7 @@ sub killSession {
 		my $login_event = {
 			'type' => 'SessionEvent',
 			'action' => 'LoggedOut',
+			'profile' => 'SessionProfile',
 			'object' => Caliper::Entity::webwork_app()
 		};
 		$caliper_sensor->sendEvents($self->{r}, [$login_event]);

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1791,6 +1791,13 @@ sub body {
 				};
 				push @$events, $paused_set_event;
 			}
+			my $tool_use_event = {
+				'type' => 'ToolUseEvent',
+				'action' => 'Used',
+				'profile' => 'ToolUseProfile',
+				'object' => Caliper::Entity::webwork_app(),
+			};
+			push @$events, $tool_use_event;
 			$caliper_sensor->sendEvents($r, $events);
 
 			# reset start time

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1725,6 +1725,7 @@ sub body {
 					my $completed_question_event = {
 						'type' => 'AssessmentItemEvent',
 						'action' => 'Completed',
+						'profile' => 'AssessmentProfile',
 						'object' => Caliper::Entity::problem_user(
 							$self->{ce},
 							$db,
@@ -1751,6 +1752,7 @@ sub body {
 				my $submitted_set_event = {
 					'type' => 'AssessmentEvent',
 					'action' => 'Submitted',
+					'profile' => 'AssessmentProfile',
 					'object' => Caliper::Entity::problem_set(
 						$self->{ce},
 						$db,
@@ -1771,6 +1773,7 @@ sub body {
 				my $paused_set_event = {
 					'type' => 'AssessmentEvent',
 					'action' => 'Paused',
+					'profile' => 'AssessmentProfile',
 					'object' => Caliper::Entity::problem_set(
 						$self->{ce},
 						$db,

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -43,6 +43,8 @@ use WeBWorK::ContentGenerator::Instructor qw(assignSetVersionToUser);
 use WeBWorK::Authen::LTIAdvanced::SubmitGrade;
 use PGrandom;
 
+use Caliper::Sensor;
+use Caliper::Entity;
 # template method
 sub templateName {
 	return "gateway";
@@ -1709,6 +1711,88 @@ sub body {
 
 			}
 		}
+
+		my $caliper_sensor = Caliper::Sensor->new($self->{ce});
+		if ($caliper_sensor->caliperEnabled()) {
+			my $events = [];
+
+			my $startTime = $r->param('startTime');
+			my $endTime = time();
+			if ($submitAnswers && $will{recordAnswers}) {
+				foreach my $i ( 0 .. $#problems ) {
+					my $problem = $problems[$i];
+					my $pg = $pg_results[$i];
+					my $completed_question_event = {
+						'type' => 'AssessmentItemEvent',
+						'action' => 'Completed',
+						'object' => Caliper::Entity::problem_user(
+							$self->{ce},
+							$db,
+							$problem->set_id(),
+							$versionNumber,
+							$problem->problem_id(),
+							$problem->user_id(),
+							$pg
+						),
+						'generated' => Caliper::Entity::answer(
+							$self->{ce},
+							$db,
+							$problem->set_id(),
+							$versionNumber,
+							$problem->problem_id(),
+							$problem->user_id(),
+							$pg,
+							0, # don't track start/end time for gateway problems (multiple answers per page)
+							0 # don't track start/end time for gateway problems (multiple answers per page)
+						),
+					};
+					push @$events, $completed_question_event;
+				}
+				my $submitted_set_event = {
+					'type' => 'AssessmentEvent',
+					'action' => 'Submitted',
+					'object' => Caliper::Entity::problem_set(
+						$self->{ce},
+						$db,
+						$setName
+					),
+					'generated' => Caliper::Entity::problem_set_attempt(
+						$self->{ce},
+						$db,
+						$setName,
+						$versionNumber,
+						$effectiveUser,
+						$startTime,
+						$endTime
+					),
+				};
+				push @$events, $submitted_set_event;
+			} else {
+				my $paused_set_event = {
+					'type' => 'AssessmentEvent',
+					'action' => 'Paused',
+					'object' => Caliper::Entity::problem_set(
+						$self->{ce},
+						$db,
+						$setName
+					),
+					'generated' => Caliper::Entity::problem_set_attempt(
+						$self->{ce},
+						$db,
+						$setName,
+						$versionNumber,
+						$effectiveUser,
+						$startTime,
+						$endTime
+					),
+				};
+				push @$events, $paused_set_event;
+			}
+			$caliper_sensor->sendEvents($r, $events);
+
+			# reset start time
+			$r->param('startTime', '');
+		}
 	}
 	debug("end answer processing");
 
@@ -2025,6 +2109,7 @@ sub body {
 
 	# else: we're not hiding answers
 	} else {
+		my $startTime = $r->param('startTime') || time();
 
 		print CGI::start_form({-name=>"gwquiz", -method=>"POST",
 				      -action=>$action}),
@@ -2035,6 +2120,7 @@ sub body {
 	#    subsequent pages of a multipage test
 		print CGI::hidden({-name=>'previewHack', -value=>''}),
 			CGI::br();
+		print CGI::hidden({-name=>'startTime', -value=>$startTime});
 		if ( $numProbPerPage && $numPages > 1 ) {
 			print CGI::hidden({-name=>'newPage', -value=>''});
 			print CGI::hidden({-name=>'currentPage',

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1195,10 +1195,11 @@ sub body {
 sub output_form_start{
 	my $self = shift;
 	my $r = $self->r;
+	my $startTime = $r->param('startTime') || time();
 
 	print CGI::start_form(-method=>"POST", -action=> $r->uri, -id=>"problemMainForm", -name=>"problemMainForm", onsubmit=>"submitAction()");
-
 	print $self->hidden_authen_fields;
+	print CGI::hidden({-name=>'startTime', -value=>$startTime});
 	return "";
 }
 

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -50,6 +50,9 @@ use Email::Sender::Simple qw(sendmail);
 use Email::Sender::Transport::SMTP qw();
 use Try::Tiny;
 
+use Caliper::Sensor;
+use Caliper::Entity;
+
 
 # process_and_log_answer subroutine.
 
@@ -277,6 +280,59 @@ sub process_and_log_answer{
 					$pureProblem->num_correct."\t".
 					$pureProblem->num_incorrect
 					);
+
+				my $caliper_sensor = Caliper::Sensor->new($self->{ce});
+				if ($caliper_sensor->caliperEnabled()) {
+					my $startTime = $r->param('startTime');
+					my $endTime = time();
+
+					my $completed_question_event = {
+						'type' => 'AssessmentItemEvent',
+						'action' => 'Completed',
+						'object' => Caliper::Entity::problem_user(
+							$self->{ce},
+							$db,
+							$problem->set_id(),
+							0, #version is 0 for non-gateway problems
+							$problem->problem_id(),
+							$problem->user_id(),
+							$pg
+						),
+						'generated' => Caliper::Entity::answer(
+							$self->{ce},
+							$db,
+							$problem->set_id(),
+							0, #version is 0 for non-gateway problems
+							$problem->problem_id(),
+							$problem->user_id(),
+							$pg,
+							$startTime,
+							$endTime
+						),
+					};
+					my $submitted_set_event = {
+						'type' => 'AssessmentEvent',
+						'action' => 'Submitted',
+						'object' => Caliper::Entity::problem_set(
+							$self->{ce},
+							$db,
+							$problem->set_id()
+						),
+						'generated' => Caliper::Entity::problem_set_attempt(
+							$self->{ce},
+							$db,
+							$problem->set_id(),
+							0, #version is 0 for non-gateway problems
+							$problem->user_id(),
+							$startTime,
+							$endTime
+						),
+					};
+					$caliper_sensor->sendEvents($r, [$completed_question_event, $submitted_set_event]);
+
+					# reset start time
+					$r->param('startTime', '');
+				}
 
 				#Try to update the student score on the LMS
 				# if that option is enabled.
@@ -516,6 +572,7 @@ sub output_main_form{
 	my $problem = $self->{problem};
 	my $set = $self->{set};
 	my $submitAnswers = $self->{submitAnswers};
+	my $startTime = $r->param('startTime') || time();
 
 	my $db = $r->db;
 	my $ce = $r->ce;
@@ -528,6 +585,7 @@ sub output_main_form{
 	print "\n";
 	print CGI::start_form(-method=>"POST", -action=> $r->uri,-name=>"problemMainForm", onsubmit=>"submitAction()");
 	print $self->hidden_authen_fields;
+	print CGI::hidden({-name=>'startTime', -value=>$startTime});
 	print CGI::end_form();
 }
 

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -330,7 +330,13 @@ sub process_and_log_answer{
 							$endTime
 						),
 					};
-					$caliper_sensor->sendEvents($r, [$completed_question_event, $submitted_set_event]);
+					my $tool_use_event = {
+						'type' => 'ToolUseEvent',
+						'action' => 'Used',
+						'profile' => 'ToolUseProfile',
+						'object' => Caliper::Entity::webwork_app(),
+					};
+					$caliper_sensor->sendEvents($r, [$completed_question_event, $submitted_set_event, $tool_use_event]);
 
 					# reset start time
 					$r->param('startTime', '');

--- a/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemUtil/ProblemUtil.pm
@@ -289,6 +289,7 @@ sub process_and_log_answer{
 					my $completed_question_event = {
 						'type' => 'AssessmentItemEvent',
 						'action' => 'Completed',
+						'profile' => 'AssessmentProfile',
 						'object' => Caliper::Entity::problem_user(
 							$self->{ce},
 							$db,
@@ -313,6 +314,7 @@ sub process_and_log_answer{
 					my $submitted_set_event = {
 						'type' => 'AssessmentEvent',
 						'action' => 'Submitted',
+						'profile' => 'AssessmentProfile',
 						'object' => Caliper::Entity::problem_set(
 							$self->{ce},
 							$db,


### PR DESCRIPTION
- Capture answer submissions (Assessment Submitted & AssessmentItem Completed events) for normal and gateway problem sets
	- Attempt durations for gateway problem sets are only stored in the overall Assessment (not individual assessment item completed events) due to multiple problems being on a page at a time
- Additionally capture Assessment Paused event for gateway problems sets (sent when changing pages to help track overall time spend on task)
- Capture login/logout events

Added new `HTTP::Async` dependency so that events can be emitted asynchronous (very important for gateway problems sets since many solutions are created at once)