### PR TITLE
Fix auth info in url

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -384,8 +384,7 @@ sub dispatch($) {
 
 			if ($bridge->useRedirect()) {
 				my $q = CGI->new();
-				my $redir = $bridge->getRedirect() . "&user=$userID&effectiveUser=$eUserID&key=" . $r->param("key");
-				print $q->redirect($redir);
+				print $q->redirect($bridge->getRedirect());
 			}
 		} else {
 			debug("Bad news: authentication failed!\n");

--- a/lib/WeBWorK/Authen/LTIAdvantage/AssignmentAndGradeService.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/AssignmentAndGradeService.pm
@@ -489,10 +489,25 @@ sub _performAssignmentAndGradeRequests {
 					);
 					next;
 				}
+				# Canvas Unpublished Assignment
+				if ($res->status_line eq '422 Unprocessable Entity' && $res->content eq '{"errors":[{"field":"grade","message":"cannot be changed at this time: This assignment is still unpublished","error_code":null}]}') {
+					$extralog->logAGSRequest(
+						"Could not update grade for unpublished Canvas assignment. " .
+						"\nRequest URI: " . $res->request->uri .
+						"\nRequest Content: " . $res->request->content
+					);
+					debug(
+						"Could not update grade for unpublished Canvas assignment. " .
+						"\nRequest URI: " . $res->request->uri .
+						"\nRequest Content: " . $res->request->content
+					);
+					next;
+				}
 				$self->{error} = "Assignment and Grades Service (LineItem Score POST) request failed. " .
 					"\nStatus: " . $res->status_line .
 					"\nRequest URI: " . $res->request->uri .
-					"\nRequest Content: " . $res->request->content;
+					"\nRequest Content: " . $res->request->content .
+					"\nResponse: " . $res->content;
 				debug($self->{error});
 				$extralog->logAGSRequest($self->{error});
 			}

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1886,7 +1886,7 @@ authentication.
 sub url_authen_args {
 	my ($self) = @_;
 
-	return $self->url_args("user", "effectiveUser", "key", "theme");
+	return $self->url_args("effectiveUser", "theme");
 }
 
 =item url_state_args()
@@ -2021,9 +2021,7 @@ sub systemLink {
 
 	my $authen = exists $options{authen} ? $options{authen} : 1;
 	if ($authen) {
-		$params{user}          = undef unless exists $params{user};
 		$params{effectiveUser} = undef unless exists $params{effectiveUser};
-		$params{key}           = undef unless exists $params{key};
 		$params{theme}         = undef unless exists $params{theme};
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -243,8 +243,8 @@ sub displayStudentStats {
 #########################################################################################
 	my $fullName = join("", $studentRecord->first_name," ", $studentRecord->last_name);
 	my $effectiveUser = $studentRecord->user_id();
-	my $act_as_student_url = "$root/$courseName/?user=".$r->param("user").
-			"&effectiveUser=$effectiveUser&key=".$r->param("key");
+	my $act_as_student_url = "$root/$courseName/?effectiveUser=$effectiveUser";
+
 
 	
 	# FIXME: why is the following not "print CGI::h3($fullName);"?  Hmm.
@@ -285,8 +285,7 @@ sub displayStudentStats {
 	my $bestGatewayScore = 0;
 	
 	foreach my $setName (@allSetIDs)   {
-		my $act_as_student_set_url = "$root/$courseName/$setName/?user=".$r->param("user").
-			"&effectiveUser=$effectiveUser&key=".$r->param("key");
+		my $act_as_student_set_url = "$root/$courseName/$setName/?effectiveUser=$effectiveUser";
 		my $set = $setsByID{ $setName };
 		my $setID = $set->set_id();  #FIXME   setName and setID should be the same
 

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -225,7 +225,7 @@ sub body {
 
 
 		# preserve the form data posted to the requested URI
-		my @fields_to_print = grep { not m/^(user|passwd|key|force_passwd_authen)$/ } $r->param;
+		my @fields_to_print = grep { not m/^(passwd|force_passwd_authen)$/ } $r->param;
 
 		#FIXME:  This next line can be removed in time.  MEG 1/27/2005
 		# warn "Error in filtering fields : |", join("|",@fields_to_print),"|" if grep {m/user/} @fields_to_print;
@@ -292,9 +292,6 @@ sub body {
 		if (@allowedGuestUsers) {
 #			print CGI::start_form({-method=>"POST", -action=>$r->uri});
 
-			# preserve the form data posted to the requested URI
-			my @fields_to_print = grep { not m/^(user|passwd|key|force_passwd_authen)$/ } $r->param;
-#			print $self->hidden_fields(@fields_to_print);
 			print CGI::br();
 			print CGI::p($r->maketext("_GUEST_LOGIN_MESSAGE", CGI::b($r->maketext("Guest Login"))));
 			print CGI::input({-type=>"submit", -name=>"login_practice_user", -value=>$r->maketext("Guest Login")});

--- a/lib/WebworkBridge/Bridges/LTILaunchBridge.pm
+++ b/lib/WebworkBridge/Bridges/LTILaunchBridge.pm
@@ -447,8 +447,8 @@ sub _updateClassGrades()
 		my $assignment_and_grade_service = WeBWorK::Authen::LTIAdvantage::AssignmentAndGradeService->new($ce, $db);
 		$assignment_and_grade_service->pushAllAssignmentGrades();
 		if ($assignment_and_grade_service->{error}) {
-			debug("There was an issue fetching updating class grades. ".$assignment_and_grade_service->{error});
-			return error("There was an issue fetching updating class grades. ".$assignment_and_grade_service->{error}, "#e017");
+			debug("There was an issue updating class grades. ".$assignment_and_grade_service->{error});
+			return error("There was an issue updating class grades. ".$assignment_and_grade_service->{error}, "#e017");
 		}
 	}
 

--- a/lib/WebworkBridge/ExtraLog.pm
+++ b/lib/WebworkBridge/ExtraLog.pm
@@ -10,6 +10,7 @@ use warnings;
 use Time::HiRes qw/gettimeofday/;
 use Date::Format;
 use WeBWorK::CourseEnvironment;
+use WeBWorK::Debug;
 
 # Constructor
 sub new

--- a/lib/WebworkBridge/lti_update_grades.pl
+++ b/lib/WebworkBridge/lti_update_grades.pl
@@ -72,7 +72,7 @@ foreach my $course_id (@course_ids) {
 		my $assignment_and_grade_service = WeBWorK::Authen::LTIAdvantage::AssignmentAndGradeService->new($tmp_ce, $tmp_db);
 		$assignment_and_grade_service->pushAllAssignmentGrades();
 		if ($assignment_and_grade_service->{error}) {
-			die "There was an issue fetching updating class grades. ".$assignment_and_grade_service->{error};
+			die "There was an issue updating class grades. ".$assignment_and_grade_service->{error};
 		}
 	};
 	if ($@) {


### PR DESCRIPTION
- Removes user and key from query params
- Auth now populates auth primarily from cookies with the following exceptions:
	- basic login requests (working off the user param)
	- webwork client requests (working of the key param)
- Shibboleth now uses cookies instead of query params
- Note: in order to get the webwork client to work, I needed to leave the hidden_user & hidden_key form fields in place (so the js can populate the user and key fields). Not 100% ideal