### PR TITLE
Improve LTI set linkage

### DIFF
--- a/lib/LTIAdvantage/Entrypoint/Launch.pm
+++ b/lib/LTIAdvantage/Entrypoint/Launch.pm
@@ -6,16 +6,15 @@ use strict;
 use warnings;
 
 use Data::Dumper;
-use URI::Escape qw(uri_escape);
+use URI::Escape;
 use CGI;
-
+use WeBWorK::Utils qw(before after between formatDateTime);
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 use WeBWorK::Debug;
 
 use LTIAdvantage::Importer::Error;
 use LTIAdvantage::Parser::LaunchParser;
-
 use WeBWorK::Authen::LTIAdvantage;
 use LTIAdvantage::Service::NamesAndRoleService;
 
@@ -136,20 +135,33 @@ sub run
 
 		# direct the student directly to a homework assignment or quiz if needed
 		my $redir = $r->uri . $course_id;
+		my $status_message = "";
 
 		if ($self->getSetId()) {
-			my $set = $db->getGlobalSet($self->getSetId());
+			my %user = $parser->get_user_info();
+			my $user_id = $user{'loginid'};
+			my $set = $db->getMergedSet($user_id, $self->getSetId());
+
 			if ($set && defined( $set->assignment_type() ) ) {
-				if ( $set->assignment_type() eq 'proctored_gateway' ) {
-					$redir .= "/proctored_quiz_mode/" . $self->getSetId();
+				my @allVersionIds = $db->listSetVersions($user_id , $self->getSetId());
+				my $latest_version = (@allVersionIds ? $allVersionIds[-1] : 0);
+
+				if (before($set->open_date)) {
+					my $display_name = $self->getSetId();
+					$display_name =~ s/_/ /g;
+					$status_message = CGI::div(
+						{class=>"ResultsWithoutError"},
+						$display_name." will open on " . formatDateTime($set->open_date, undef, $tmpce->{studentDateDisplayFormat})
+					);
+				} elsif ( $set->assignment_type() eq 'proctored_gateway' ) {
+					$redir .= "/proctored_quiz_mode/" . $self->getSetId() . ($latest_version ? ",v$latest_version" : "");
 				} elsif ( $set->assignment_type() eq 'gateway' ) {
-					$redir .= "/quiz_mode/" . $self->getSetId();
+					$redir .= "/quiz_mode/" . $self->getSetId() . ($latest_version ? ",v$latest_version" : "");
 				} else {
 					$redir .= "/" . $self->getSetId();
 				}
 			}
 		}
-		$redir .= "?lti=1";
 		if (-e $tmpce->{courseDirs}->{root}) {
 			# course exists
 			$self->_updateLTISettings();
@@ -170,14 +182,15 @@ sub run
 			# ensure current user can access even if membership fails
 			$self->_updateLaunchUser();
 
-			my $message = "The course was successfully imported into Webwork.";
-			$redir .= "&status_message=".uri_escape(CGI::div({class=>"ResultsWithoutError"}, $message));
+			$status_message = CGI::div(
+				{class=>"ResultsWithoutError"},
+				"The course was successfully imported into Webwork."
+			);
 		}
-
 		# ensure authentification module is used
 		$self->{useAuthenModule} = 1;
 		$self->{useRedirect} = 1;
-		$self->{redirect} = $redir;
+		$self->{redirect} = $redir."?lti=1&status_message=".uri_escape_utf8($status_message);
 	}
 
 	return 0;

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -142,7 +142,7 @@ sub initialize {
 	
 	my $user               = $r->param("user");
 	my $effectiveUser      = $r->param("effectiveUser");
-	if ($authz->hasPermissions($user, "access_instructor_tools")) {
+	if ($authz->hasPermissions($user, "access_instructor_tools") || (defined($r->param("lti")) && $r->param("lti") eq "1")) {
 		# get result and send to message
 		my $status_message = $r->param("status_message");
 		$self->addmessage(CGI::p("$status_message")) if $status_message;


### PR DESCRIPTION
- If the set hasn't begun yet, redirect the user to the set list screen with a message indicating when the set will open
- If the set is open/concluded then link directly to the set
	- if it is a quiz/proctored quiz, then link to the latest version if one is available
- Modified `initialize` in ProblemSets.pm so that the status message will display for students as well for LTI launches

Closes #20, Closes #33 